### PR TITLE
Set up empty Dagster development and production deployments

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,4 +18,5 @@ jobs:
       - name: Test with pytest
         run: |
           export PYTHONPATH=$(pwd)
+          export DEFINITIONS=dev
           python -m pytest --cov=. --cov-config=.coverage_rc --cov-report=term-missing

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# Project artifacts
+dagster/
+downloads/
+*logs/
+*.logs_queue
+*.nux
+docker-compose.override.yaml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -11,7 +19,6 @@ __pycache__/
 build/
 develop-eggs/
 dist/
-downloads/
 eggs/
 .eggs/
 lib/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,19 @@
-FROM python:3.11
+FROM python:3.12
 ENV PYTHONUNBUFFERED True
 ENV PYTHONPATH /
+ENV DAGSTER_HOME=/opt/app
 
 WORKDIR /
-COPY ./requirements /requirements
 
+COPY requirements /requirements
+RUN apt-get update
+RUN xargs -a /requirements/apt_requirements.txt apt-get install -y
 RUN pip install --no-cache-dir --upgrade -r /requirements/pip_requirements.txt
 
-COPY . /
+COPY pyproject.toml /opt/app/pyproject.toml
+COPY config/prod/dagster.yaml /opt/app/dagster.yaml
+COPY src /opt/app/src
 
-ENTRYPOINT ["uvicorn", "--host", "0.0.0.0", "--port", "8080"]
+WORKDIR /opt/app
+
+CMD ["dagster", "dev", "-h", "0.0.0.0", "-p", "12000", "--python-file", "src/__init__.py"]

--- a/README.md
+++ b/README.md
@@ -1,13 +1,35 @@
 # avalanche-forecast
 
-Personal project to use ML to forecast regional avalanche risks and avalanche problem types.
+Personal project using ML to forecast regional avalanche risks and avalanche problem types.
 
-## Getting Started
+## Installation
 
-Add the following to the end of your shell's `~/.profile` script.
-Note that the `~/.profile` script name varies according to your shell. Run `echo $0` to get the shell you are using.
+Install [docker compose](https://docs.docker.com/compose/install/)
 
-```sh
+Navigate to the repo home directory and build the docker images:
+```shell
+docker compose build
+```
+
+## Execution
+
+Run in production (data will be persisted):
+```shell
+docker compose up -f docker-compose.yaml -f docker-compose.prod.yaml
+```
+
+Run in development (data will be transient, live updates to code will be reflected during execution):
+```shell
+docker compose up -f docker-compose.yaml -f docker-compose.dev.yaml
+```
+
+## Convenience Utilities
+
+A number of terminal aliases have been added for convenience to [terminal_aliases.sh](https://github.com/jfishb01/avalanche-forecast/blob/main/terminal_aliases.sh).
+
+To have these aliases loaded when navigating to this project, add the following to the
+end of your shell's profile script:
+```shell
 AVALANCHE_FORECAST_REPO=/path/to/this/repo
 
 cd_avalanche_forecast() {
@@ -16,5 +38,5 @@ cd_avalanche_forecast() {
 }
 ```
 
-Close out of your current terminal tab and reopen it. You can now run `cd_avalanche_forecast` to cd into this
-repo. This will give you access to all the utility terminal aliases in `terminal_aliases.sh`.
+Close out of your current terminal tab and reopen it. You can now run `cd_avalanche_forecast` to
+cd into this repo and load all the project terminal aliases.

--- a/config/dev/dagster.yaml
+++ b/config/dev/dagster.yaml
@@ -1,0 +1,25 @@
+telemetry:
+  enabled: false
+sensors:
+  use_threads: true
+  num_workers: 8
+schedules:
+  use_threads: true
+  num_workers: 8
+storage:
+  sqlite:
+    base_dir: dagster/dev/
+code_servers:
+  local_startup_timeout: 300
+run_coordinator:
+  module: dagster.core.run_coordinator
+  class: QueuedRunCoordinator
+  config:
+    max_concurrent_runs: 32
+    dequeue_interval_seconds: 1
+    dequeue_use_threads: true
+    dequeue_num_workers: 32
+    user_code_failure_retry_delay: 5
+run_monitoring:
+  enabled: true
+  free_slots_after_run_end_seconds: 15 # free any hanging concurrency slots after 15 seconds from the end of a run

--- a/config/prod/dagster.yaml
+++ b/config/prod/dagster.yaml
@@ -1,0 +1,33 @@
+telemetry:
+  enabled: false
+sensors:
+  use_threads: true
+  num_workers: 8
+schedules:
+  use_threads: true
+  num_workers: 8
+storage:
+  postgres:
+    postgres_db:
+      hostname: dagster-postgres
+      username: postgres
+      password:
+        env: POSTGRES_PASSWORD
+      db_name: postgres
+      port: 5432
+run_coordinator:
+  module: dagster.core.run_coordinator
+  class: QueuedRunCoordinator
+  config:
+    max_concurrent_runs: 8
+    dequeue_interval_seconds: 1
+    dequeue_use_threads: true
+    dequeue_num_workers: 8
+    user_code_failure_retry_delay: 30
+    tag_concurrency_limits:
+      - key: "no_concurrency"
+        value: "true"
+        limit: 1
+run_monitoring:
+  enabled: true
+  free_slots_after_run_end_seconds: 15 # free any hanging concurrency slots after 15 seconds from the end of a run

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,0 +1,12 @@
+version: '3.7'
+services:
+  dagster-webserver:
+    ports:
+      - "11000:11000"
+    environment:
+      - DEFINITIONS=dev
+      - DAGSTER_HOME=/opt/dev/config/dev
+    volumes:
+      - ./:/opt/dev
+    working_dir: /opt/dev
+    command: dagster dev -h "0.0.0.0" -p 11000 --python-file "src/__init__.py"

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,0 +1,29 @@
+version: '3.7'
+services:
+  dagster-webserver:
+    ports:
+      - "12000:12000"
+    depends_on:
+      dagster-postgres:
+        condition: service_healthy
+    environment:
+      - POSTGRES_PASSWORD=dagster_postgres_pwd
+      - DEFINITIONS=prod
+
+  dagster-postgres:
+    image: "postgres:latest"
+    user: postgres
+    restart: always
+    # set shared memory limit when using docker-compose
+    shm_size: 128mb
+    environment:
+      POSTGRES_PASSWORD: dagster_postgres_pwd
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready", "-p", "5432" ]
+      interval: 3s
+      timeout: 5s
+      retries: 10
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./dagster/prod/postgresql/data:/var/lib/postgresql/data

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,4 @@
+version: '3.7'
+services:
+  dagster-webserver:
+    build: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "avalanche-forecast"
+version = "0.0.1"
+description = "Forecast regional avalanche risks and problem types using ML"
+readme = "README.md"
+requires-python = ">=3.12"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+dynamic = ["dependencies"]
+authors = [
+  {name = "Josh Fishbein", email = "joshua.p.fishbein@gmail.com"},
+]
+
+[project.urls]
+Homepage = "https://github.com/jfishb01/avalanche-forecast"
+Tracker = "https://github.com/jfishb01/avalanche-forecast/issues"
+
+[tool.dagster]
+module_name = "src"

--- a/requirements/pip_requirements.txt
+++ b/requirements/pip_requirements.txt
@@ -12,4 +12,10 @@ clickhouse-sqlalchemy<1.0
 scikit-learn>=1.3,<2.0
 matplotlib>=3.0,<4.0
 mlflow>=2.8,<=3.0
-pandera>=0.18.0
+dagster
+dagster-duckdb
+dagster-duckdb-pandas
+dagster-postgres
+dagster-docker
+dagster-pandera
+dagster-webserver

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,28 @@
+import os
+import warnings
+from dagster import (
+    load_assets_from_modules,
+    Definitions,
+    ExperimentalWarning,
+)
+
+from src.definitions import dev_definitions, prod_definitions
+
+warnings.filterwarnings("ignore", category=ExperimentalWarning)
+
+all_assets = load_assets_from_modules([])
+
+env_resources = {
+    "DEV": dev_definitions.get_resources,
+    "PROD": prod_definitions.get_resources,
+}
+env_definitions = os.getenv("DEFINITIONS").upper()
+
+
+defs = Definitions(
+    assets=all_assets,
+    jobs=[],
+    resources=env_resources[env_definitions](),
+    sensors=[],
+    schedules=[],
+)

--- a/src/definitions/dev_definitions.py
+++ b/src/definitions/dev_definitions.py
@@ -1,0 +1,5 @@
+from typing import Dict
+from dagster import ResourceDefinition
+
+def get_resources() -> Dict[str, ResourceDefinition]:
+    return {}

--- a/src/definitions/dev_definitions.py
+++ b/src/definitions/dev_definitions.py
@@ -1,5 +1,6 @@
 from typing import Dict
 from dagster import ResourceDefinition
 
+
 def get_resources() -> Dict[str, ResourceDefinition]:
     return {}

--- a/src/definitions/prod_definitions.py
+++ b/src/definitions/prod_definitions.py
@@ -1,0 +1,5 @@
+from typing import Dict
+from dagster import ResourceDefinition
+
+def get_resources() -> Dict[str, ResourceDefinition]:
+    return {}

--- a/src/definitions/prod_definitions.py
+++ b/src/definitions/prod_definitions.py
@@ -1,5 +1,6 @@
 from typing import Dict
 from dagster import ResourceDefinition
 
+
 def get_resources() -> Dict[str, ResourceDefinition]:
     return {}

--- a/src/ingestion/avalanche_forecast/load.py
+++ b/src/ingestion/avalanche_forecast/load.py
@@ -1,6 +1,5 @@
 """Load transformed avalanche forecast data from regional forecast distributors to a DB."""
 
-
 import os
 import logging
 import argparse

--- a/src/ml/training/evaluation/metrics.py
+++ b/src/ml/training/evaluation/metrics.py
@@ -24,15 +24,17 @@ def _get_evaluation_classifier_metrics(
             (evaluation_set["distributor"] == area.distributor)
             & (evaluation_set["area_id"] == area.area_id)
         ]
-        eval_metrics_by_area[f"accuracy - {area.distributor}.{area.area_name}"] = (
+        eval_metrics_by_area[f"accuracy - {area.distributor}.{area.area_name}"] = round(
             metrics.accuracy_score(
                 evaluation_set_by_area["observed"], evaluation_set_by_area["predicted"]
-            ).round(3)
+            ),
+            3,
         )
 
-    eval_metrics_aggregate["accuracy"] = metrics.accuracy_score(
-        evaluation_set["observed"], evaluation_set["predicted"]
-    ).round(3)
+    eval_metrics_aggregate["accuracy"] = round(
+        metrics.accuracy_score(evaluation_set["observed"], evaluation_set["predicted"]),
+        3,
+    )
     eval_metrics_aggregate["min_accuracy"] = min(eval_metrics_by_area.values())
     eval_metrics_aggregate["max_accuracy"] = max(eval_metrics_by_area.values())
     return dict(**eval_metrics_aggregate, **eval_metrics_by_area)

--- a/src/ml/training/evaluation/metrics.py
+++ b/src/ml/training/evaluation/metrics.py
@@ -24,12 +24,10 @@ def _get_evaluation_classifier_metrics(
             (evaluation_set["distributor"] == area.distributor)
             & (evaluation_set["area_id"] == area.area_id)
         ]
-        eval_metrics_by_area[
-            f"accuracy - {area.distributor}.{area.area_name}"
-        ] = metrics.accuracy_score(
-            evaluation_set_by_area["observed"], evaluation_set_by_area["predicted"]
-        ).round(
-            3
+        eval_metrics_by_area[f"accuracy - {area.distributor}.{area.area_name}"] = (
+            metrics.accuracy_score(
+                evaluation_set_by_area["observed"], evaluation_set_by_area["predicted"]
+            ).round(3)
         )
 
     eval_metrics_aggregate["accuracy"] = metrics.accuracy_score(

--- a/src/ml/training/evaluation/visuals.py
+++ b/src/ml/training/evaluation/visuals.py
@@ -94,13 +94,15 @@ def save_evaluation_accuracy_plot(
                 error_points["predicted"].tolist(),
                 PREDICTED_MARKER,
             ),
-            ScatterPlotCategory(
-                correct_points["analysis_date"].tolist(),
-                correct_points["observed"].tolist(),
-                CORRECT_MARKER,
-            )
-            if show_correct_forecasts
-            else None,
+            (
+                ScatterPlotCategory(
+                    correct_points["analysis_date"].tolist(),
+                    correct_points["observed"].tolist(),
+                    CORRECT_MARKER,
+                )
+                if show_correct_forecasts
+                else None
+            ),
         ),
     )
 

--- a/terminal_aliases.sh
+++ b/terminal_aliases.sh
@@ -27,7 +27,7 @@ start_webserver() {
   # Example usage: start_webserver path.to.app:app_name 8181
   app=$1
   port=$2
-  docker run --rm -it -p ${port:-8080}:3000 $WEBSERVER_IMAGE_NAME $app
+  docker run --rm -it -p ${port:-8080}:8080 $WEBSERVER_IMAGE_NAME $app
 }
 
 start_local() {

--- a/terminal_aliases.sh
+++ b/terminal_aliases.sh
@@ -1,6 +1,11 @@
-# Terminal aliases to improve development iteration.
-#
-# See the "Getting Started" section of this repo's README to configure these aliases.
+# Project terminal aliases. See the root README for notes on configuring.
+
+set_env() {
+  # Options include "dev" or "prod"
+  env=$1
+  rm ./docker-compose.override.yaml
+  ln -s ./docker-compose.$env.yaml ./docker-compose.override.yaml
+}
 
 
 WEBSERVER_IMAGE_NAME="avalanche-forecast-webserver"
@@ -22,7 +27,7 @@ start_webserver() {
   # Example usage: start_webserver path.to.app:app_name 8181
   app=$1
   port=$2
-  docker run --rm -it -p ${port:-8080}:8080 $WEBSERVER_IMAGE_NAME $app
+  docker run --rm -it -p ${port:-8080}:3000 $WEBSERVER_IMAGE_NAME $app
 }
 
 start_local() {


### PR DESCRIPTION
Sets up an empty Dagster development and production deployment. The intent is to begin migrating the existing webserver applications over to the new Dagster orchestrator